### PR TITLE
feat: キーワード検索・フィルタ機能を実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,17 @@ import { useState } from 'react';
 import { Board } from './components/Board/Board';
 import { TaskModal } from './components/TaskModal/TaskModal';
 import { ConfirmDialog } from './components/ui/ConfirmDialog';
+import { SearchBar } from './components/ui/SearchBar';
 import { useTasks } from './hooks/useTasks';
+import { useDebounce } from './hooks/useDebounce';
 import type { ColumnId, ModalState, Task, TaskFormValues } from './types';
 
 export default function App() {
   const { tasks, addTask, updateTask, deleteTask, moveTask, reorderTasks } = useTasks();
   const [modalState, setModalState] = useState<ModalState>({ mode: 'closed' });
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const debouncedQuery = useDebounce(searchQuery, 300);
 
   function handleAddTask(columnId: ColumnId) {
     setModalState({ mode: 'add', columnId });
@@ -40,13 +44,15 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-slate-100">
-      <header className="bg-white border-b border-gray-200 px-6 py-4 shadow-sm">
-        <h1 className="text-xl font-bold text-gray-800">カンバンボード</h1>
+      <header className="bg-white border-b border-gray-200 px-6 py-3 shadow-sm flex items-center justify-between gap-4">
+        <h1 className="text-xl font-bold text-gray-800 shrink-0">カンバンボード</h1>
+        <SearchBar value={searchQuery} onChange={setSearchQuery} />
       </header>
 
       <main className="p-4 md:p-6">
         <Board
           tasks={tasks}
+          searchQuery={debouncedQuery}
           moveTask={moveTask}
           reorderTasks={reorderTasks}
           onAddTask={handleAddTask}

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { DndContext, DragOverlay, closestCorners } from '@dnd-kit/core';
 import { Column } from '../Column/Column';
 import { TaskCardOverlay } from '../TaskCard/TaskCardOverlay';
@@ -7,6 +8,7 @@ import { useDragAndDrop } from '../../hooks/useDragAndDrop';
 
 interface BoardProps {
   tasks: Task[];
+  searchQuery: string;
   moveTask: (taskId: string, newColumnId: ColumnId, overTaskId?: string) => void;
   reorderTasks: (taskId: string, overTaskId: string) => void;
   onAddTask: (columnId: ColumnId) => void;
@@ -14,12 +16,22 @@ interface BoardProps {
   onDeleteTask: (taskId: string) => void;
 }
 
-export function Board({ tasks, moveTask, reorderTasks, onAddTask, onEditTask, onDeleteTask }: BoardProps) {
+export function Board({ tasks, searchQuery, moveTask, reorderTasks, onAddTask, onEditTask, onDeleteTask }: BoardProps) {
   const { activeTask, sensors, onDragStart, onDragOver, onDragEnd } = useDragAndDrop({
     tasks,
     moveTask,
     reorderTasks,
   });
+
+  const matchedTaskIds = useMemo<Set<string>>(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return new Set(tasks.map(t => t.id));
+    return new Set(
+      tasks
+        .filter(t => t.title.toLowerCase().includes(q) || t.description.toLowerCase().includes(q))
+        .map(t => t.id)
+    );
+  }, [tasks, searchQuery]);
 
   return (
     <DndContext
@@ -35,6 +47,8 @@ export function Board({ tasks, moveTask, reorderTasks, onAddTask, onEditTask, on
             key={column.id}
             column={column}
             tasks={tasks.filter(t => t.columnId === column.id)}
+            matchedTaskIds={matchedTaskIds}
+            searchQuery={searchQuery}
             onAddTask={onAddTask}
             onEditTask={onEditTask}
             onDeleteTask={onDeleteTask}

--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -7,15 +7,19 @@ import type { Column as ColumnType, ColumnId, Task } from '../../types';
 interface ColumnProps {
   column: ColumnType;
   tasks: Task[];
+  matchedTaskIds: Set<string>;
+  searchQuery: string;
   onAddTask: (columnId: ColumnId) => void;
   onEditTask: (task: Task) => void;
   onDeleteTask: (taskId: string) => void;
 }
 
-export function Column({ column, tasks, onAddTask, onEditTask, onDeleteTask }: ColumnProps) {
+export function Column({ column, tasks, matchedTaskIds, searchQuery, onAddTask, onEditTask, onDeleteTask }: ColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id: column.id });
 
   const taskIds = tasks.map(t => t.id);
+  const isSearching = searchQuery.trim() !== '';
+  const hasMatch = tasks.some(t => matchedTaskIds.has(t.id));
 
   return (
     <div className={`flex flex-col rounded-xl border-t-4 ${column.color} bg-gray-50 p-3 min-h-[500px] transition-colors ${isOver ? 'bg-blue-50' : ''}`}>
@@ -23,12 +27,17 @@ export function Column({ column, tasks, onAddTask, onEditTask, onDeleteTask }: C
 
       <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>
         <div ref={setNodeRef} className="flex flex-col gap-2 flex-1">
+          {isSearching && !hasMatch && tasks.length > 0 && (
+            <p className="text-xs text-gray-400 text-center py-3">該当するタスクはありません</p>
+          )}
           {tasks.map(task => (
             <TaskCard
               key={task.id}
               task={task}
               onEdit={onEditTask}
               onDelete={onDeleteTask}
+              isMatch={matchedTaskIds.has(task.id)}
+              searchQuery={searchQuery}
             />
           ))}
         </div>

--- a/src/components/TaskCard/TaskCard.tsx
+++ b/src/components/TaskCard/TaskCard.tsx
@@ -2,6 +2,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { useSortable } from '@dnd-kit/sortable';
 import { Calendar, Pencil, Trash2 } from 'lucide-react';
 import { Badge } from '../ui/Badge';
+import { HighlightText } from '../ui/HighlightText';
 import { formatDate, isOverdue } from '../../utils/dateUtils';
 import type { Task } from '../../types';
 
@@ -9,9 +10,11 @@ interface TaskCardProps {
   task: Task;
   onEdit: (task: Task) => void;
   onDelete: (taskId: string) => void;
+  isMatch?: boolean;
+  searchQuery?: string;
 }
 
-export function TaskCard({ task, onEdit, onDelete }: TaskCardProps) {
+export function TaskCard({ task, onEdit, onDelete, isMatch = true, searchQuery = '' }: TaskCardProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: task.id });
 
   const style = {
@@ -20,19 +23,22 @@ export function TaskCard({ task, onEdit, onDelete }: TaskCardProps) {
   };
 
   const overdue = isOverdue(task.dueDate);
+  const dimmed = searchQuery.trim() !== '' && !isMatch;
 
   return (
     <div
       ref={setNodeRef}
       style={style}
-      className={`group bg-white rounded-lg shadow-sm border border-gray-200 p-3 cursor-grab active:cursor-grabbing select-none ${isDragging ? 'opacity-40' : ''}`}
+      className={`group bg-white rounded-lg shadow-sm border border-gray-200 p-3 cursor-grab active:cursor-grabbing select-none transition-opacity ${isDragging ? 'opacity-40' : dimmed ? 'opacity-40' : 'opacity-100'}`}
       {...attributes}
       {...listeners}
     >
       <div className="flex items-start justify-between gap-2">
-        <p className="text-sm font-medium text-gray-800 break-words flex-1 leading-snug">
-          {task.title}
-        </p>
+        <HighlightText
+          text={task.title}
+          query={searchQuery}
+          className="text-sm font-medium text-gray-800 break-words flex-1 leading-snug"
+        />
         <div
           className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
           onClick={e => e.stopPropagation()}
@@ -56,9 +62,11 @@ export function TaskCard({ task, onEdit, onDelete }: TaskCardProps) {
       </div>
 
       {task.description && (
-        <p className="mt-1.5 text-xs text-gray-500 line-clamp-2 break-words">
-          {task.description}
-        </p>
+        <HighlightText
+          text={task.description}
+          query={searchQuery}
+          className="mt-1.5 text-xs text-gray-500 line-clamp-2 break-words block"
+        />
       )}
 
       {task.dueDate && (

--- a/src/components/ui/HighlightText.tsx
+++ b/src/components/ui/HighlightText.tsx
@@ -1,0 +1,28 @@
+interface HighlightTextProps {
+  text: string;
+  query: string;
+  className?: string;
+}
+
+export function HighlightText({ text, query, className }: HighlightTextProps) {
+  if (!query.trim()) {
+    return <span className={className}>{text}</span>;
+  }
+
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const parts = text.split(new RegExp(`(${escaped})`, 'gi'));
+
+  return (
+    <span className={className}>
+      {parts.map((part, i) =>
+        part.toLowerCase() === query.toLowerCase() ? (
+          <mark key={i} className="bg-yellow-200 text-gray-900 rounded-sm px-0.5">
+            {part}
+          </mark>
+        ) : (
+          part
+        )
+      )}
+    </span>
+  );
+}

--- a/src/components/ui/SearchBar.tsx
+++ b/src/components/ui/SearchBar.tsx
@@ -1,0 +1,30 @@
+import { Search, X } from 'lucide-react';
+
+interface SearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function SearchBar({ value, onChange }: SearchBarProps) {
+  return (
+    <div className="relative flex items-center">
+      <Search size={16} className="absolute left-3 text-gray-400 pointer-events-none" />
+      <input
+        type="text"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder="タスクを検索..."
+        className="pl-9 pr-8 py-1.5 text-sm bg-gray-100 border border-transparent rounded-lg focus:outline-none focus:bg-white focus:border-gray-300 transition-colors w-56"
+      />
+      {value && (
+        <button
+          onClick={() => onChange('')}
+          className="absolute right-2 text-gray-400 hover:text-gray-600 transition-colors"
+          aria-label="検索をクリア"
+        >
+          <X size={14} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounced;
+}


### PR DESCRIPTION
## 概要

Issue #1 の実装。ヘッダーにキーワード検索バーを追加し、タスクをリアルタイムで絞り込めるようにした。

## 変更内容

### 新規ファイル
- `src/hooks/useDebounce.ts` — 汎用デバウンスフック (300ms)
- `src/components/ui/SearchBar.tsx` — 検索バーUI（クリアボタン付き）
- `src/components/ui/HighlightText.tsx` — 検索ワードのハイライト表示コンポーネント

### 変更ファイル
- `src/App.tsx` — `searchQuery` state・`useDebounce`・`SearchBar` を追加
- `src/components/Board/Board.tsx` — `searchQuery` を受け取り `matchedTaskIds` を `useMemo` で算出
- `src/components/Column/Column.tsx` — `matchedTaskIds`・`searchQuery` を受け取り空状態メッセージを表示
- `src/components/TaskCard/TaskCard.tsx` — `isMatch`・`searchQuery` を受け取りハイライト・薄表示に対応

## 動作仕様

| 仕様 | 詳細 |
|------|------|
| 検索対象 | タイトル・説明（部分一致・大文字小文字区別なし） |
| デバウンス | 300ms（高速入力でも再レンダリングを抑制） |
| 非マッチカード | `opacity-40` で薄表示（DnD は引き続き動作） |
| ハイライト | 一致部分を黄色 `<mark>` タグで強調 |
| 空状態 | マッチゼロのカラムに「該当するタスクはありません」を表示 |
| クリア | × ボタンまたは入力削除で即座にリセット |

## 受け入れ条件チェック

- [x] 検索ワードを入力するとリアルタイムでカードが絞り込まれる
- [x] 大文字小文字を区別しない
- [x] 検索中もドラッグ&ドロップが正常に動作する
- [x] クリアボタンで検索状態がリセットされる
- [x] 検索結果がゼロの場合「該当するタスクはありません」とカラムに表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)